### PR TITLE
fix import of color

### DIFF
--- a/src/components/Image/Image.js
+++ b/src/components/Image/Image.js
@@ -1,7 +1,7 @@
 import { Component, createRef, createElement } from 'react'
 import PropTypes from 'prop-types'
 import CircularProgress from '@mui/material/CircularProgress';
-import common from '@mui/material/colors/common'
+import { common } from '@mui/material/colors'
 import BrokenImage from '@mui/icons-material/BrokenImage'
 
 function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }


### PR DESCRIPTION
I run into this issue when running vitest for my project.

```
 FAIL  src/components/header/Header.test.tsx [ src/components/header/Header.test.tsx ]
SyntaxError: Unexpected token 'export'
 ❯ Object.compileFunction node:vm:360:18
 ❯ Object.<anonymous> node_modules/@jy95/material-ui-image/lib/components/Image/Image.js:16:38

Module /workspaces/viseron/frontend/node_modules/@mui/material/colors/common.js:5 seems to be an ES Module but shipped in a CommonJS package. You might want to create an issue to the package "@mui/material" asking them to ship the file in .mjs extension or add "type": "module" in their package.json.

As a temporary workaround you can try to inline the package by updating your config:

// vitest.config.js
export default {
  test: {
    deps: {
      inline: [
        "@mui/material"
      ]
    }
  }
}
```

The 4-level imports are not supported by MUI